### PR TITLE
Add d3 to dependencies. This is required to support webpack require.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 npm-debug.log
 .prodio
+.idea

--- a/package.json
+++ b/package.json
@@ -16,12 +16,14 @@
   "license": "MIT",
   "devDependencies": {
     "browserify": "^6.3.2",
-    "d3": "^3.4.13",
     "gulp": "^3.8.10",
     "gulp-react": "^2.0.0",
     "gulp-rename": "^1.2.0",
     "react": "^0.12.0",
     "reactify": "^0.16.0",
     "vinyl-source-stream": "^1.0.0"
+  },
+  "dependencies": {
+    "d3": "^3.5.3"
   }
 }


### PR DESCRIPTION
I wasn't able to use the npm module as is, since I get errors complaining about not having d3. When installing as a module via npm, d3 is not installed, since it is under dev dependencies. Adding it as a regular dependency fixed the issue. I also tried just using the built module, but this seems to cause issues with React.
